### PR TITLE
Find libusb, Bloody AL9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
 project(bloody)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -I/usr/include/libusb-1.0  -lusb-1.0") #TODO: findlibusb
+find_package(PkgConfig REQUIRED)
+pkg_search_module(LIBUSB1 REQUIRED libusb-1.0)
+include_directories(SYSTEM ${LIBUSB1_INCLUDE_DIRS})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(SOURCE_FILES
     main.cpp)
 
 add_executable(bloody ${SOURCE_FILES} Mouse.cpp Mouse.h)
+target_link_libraries(bloody ${LIBUSB1_LIBRARIES})

--- a/Mouse.cpp
+++ b/Mouse.cpp
@@ -154,6 +154,9 @@ void Mouse::listDevices() {
             case BLOODY_R3_PID:
                 name = "Bloody R3";
                 break;
+            case BLOODY_AL9_PID:
+                name = "Bloody AL9";
+                break;
             default:
                 name = "Unknown";
         }

--- a/Mouse.h
+++ b/Mouse.h
@@ -15,8 +15,9 @@ static const int BLOODY_V8_PID = 0x11F5;
 static const int BLOODY_R7_PID = 0x1485;
 static const int BLOODY_R8_1_PID = 0x14ee;
 static const int BLOODY_R3_PID = 0x1a5a;
+static const int BLOODY_AL9_PID = 0xf633;
 
-static const int COMPATIBLE_PIDS[] = {BLOODY_V5_PID, BLOODY_V7_PID, BLOODY_V8_PID, BLOODY_R7_PID, BLOODY_R8_1_PID, BLOODY_R3_PID};
+static const int COMPATIBLE_PIDS[] = {BLOODY_V5_PID, BLOODY_V7_PID, BLOODY_V8_PID, BLOODY_R7_PID, BLOODY_R8_1_PID, BLOODY_R3_PID, BLOODY_AL9_PID};
 static const size_t COMPATIBLE_PIDS_SIZE = sizeof(COMPATIBLE_PIDS)/sizeof(COMPATIBLE_PIDS[0]);
 
 static const int A4TECH_MAGIC = 0x07;


### PR DESCRIPTION
* In CMake, use `pkgconfig` to find `libusb-1.0` and set the appropriate flags
* Add _Bloody AL9_ to the list of supported mice